### PR TITLE
fix: split FileControlRecord into separate Header/Trailer classes

### DIFF
--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/FileHeaderRecord.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/FileHeaderRecord.cs
@@ -1,0 +1,14 @@
+namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
+
+public class FileHeaderRecord
+{
+    public string? RecordTypeIdentifier { get; set; }
+
+    public string? ExtractId { get; set; }
+
+    public string? TransferStartDate { get; set; }
+
+    public string? TransferStartTime { get; set; }
+
+    public string? RecordCount { get; set; }
+}

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/FileTrailerRecord.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/FileTrailerRecord.cs
@@ -1,14 +1,14 @@
 namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
 
-public class FileControlRecord
+public class FileTrailerRecord
 {
     public string? RecordTypeIdentifier { get; set; }
 
     public string? ExtractId { get; set; }
 
-    public string? TransferStartDate { get; set; }
+    public string? TransferEndDate { get; set; }
 
-    public string? TransferStartTime { get; set; }
+    public string? TransferEndTime { get; set; }
 
     public string? RecordCount { get; set; }
 }

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/ParsedFile.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Models/ParsedFile.cs
@@ -2,8 +2,8 @@ namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
 
 public class ParsedFile
 {
-    public FileControlRecord? FileHeader { get; set; }
-    public FileControlRecord? FileTrailer { get; set; }
+    public FileHeaderRecord? FileHeader { get; set; }
+    public FileTrailerRecord? FileTrailer { get; set; }
     public required List<string> ColumnHeadings { get; set; } = [];
     public required List<FileDataRecord> DataRecords { get; set; } = [];
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Realised that the Header and Trailer rows in NBSS Appointment Event files are subtly different - the dates and times refer to the transfer start and end time respectively. Hence they should have different names.
So have replaced the general FileControlRecord class with separate FileHeaderRecord and FileTrailerRecord classes with appropriately named fields.

## Context

- No confusion over the meaning of TransferStartTime vs TransferEndTime
- Enables targeted validation: e.g., your HeaderTransferTimeValidator won’t mistakenly run against trailer data
- Self-documenting code: each class maps clearly to the file section it represents
- Can still share parsing logic if the structure is similar, but the model won’t lie

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
