### PR TITLE
feat: DTOSS-9160 - NHS Num validator

### DIFF
--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidator.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+
+namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+public partial class NhsNumValidator() :
+    RegexValidator("NHS Num", NhsNumberRegex(), ErrorCodes.MissingNhsNum, ErrorCodes.InvalidNhsNum)
+{
+    protected override IEnumerable<ValidationError> RunAdditionalChecks(int rowNumber, string value)
+    {
+        if (!HasValidCheckDigit(value))
+        {
+            yield return new ValidationError
+            {
+                RowNumber = rowNumber,
+                Field = FieldName,
+                Error = "NHS Num has invalid check digit",
+                Code = ErrorCodes.InvalidNhsNumCheckDigit
+            };
+        }
+    }
+
+    private static bool HasValidCheckDigit(string value)
+    {
+        var weightedSum = 0;
+        for (var i = 0; i < 9; i++)
+        {
+            weightedSum += (10 - i) * (value[i] - '0');
+        }
+
+        var remainder = weightedSum % 11;
+        var expectedCheckDigit = (11 - remainder) % 11;
+
+        return expectedCheckDigit == value[9] - '0';
+    }
+
+    [GeneratedRegex(@"^\d{10}$", RegexOptions.Compiled)]
+    private static partial Regex NhsNumberRegex();
+}

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/RegexValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/RegexValidator.cs
@@ -10,17 +10,19 @@ public class RegexValidator(
     string errorCodeInvalidFormat)
     : IRecordValidator
 {
+    protected string FieldName { get; } = fieldName;
+
     public IEnumerable<ValidationError> Validate(FileDataRecord fileDataRecord)
     {
-        var value = fileDataRecord[fieldName];
+        var value = fileDataRecord[FieldName];
 
         if (value == null)
         {
             yield return new ValidationError
             {
                 RowNumber = fileDataRecord.RowNumber,
-                Field = fieldName,
-                Error = $"{fieldName} is missing",
+                Field = FieldName,
+                Error = $"{FieldName} is missing",
                 Code = errorCodeMissing,
             };
             yield break;
@@ -31,10 +33,21 @@ public class RegexValidator(
             yield return new ValidationError
             {
                 RowNumber = fileDataRecord.RowNumber,
-                Field = fieldName,
-                Error = $"{fieldName} is in an invalid format",
+                Field = FieldName,
+                Error = $"{FieldName} is in an invalid format",
                 Code = errorCodeInvalidFormat,
             };
+            yield break;
         }
+
+        foreach (var additionalError in RunAdditionalChecks(fileDataRecord.RowNumber, value))
+        {
+            yield return additionalError;
+        }
+    }
+
+    protected virtual IEnumerable<ValidationError> RunAdditionalChecks(int rowNumber, string value)
+    {
+        yield break;
     }
 }

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidatorRegistry.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidatorRegistry.cs
@@ -24,6 +24,7 @@ public static partial class ValidatorRegistry
                 ErrorCodes.InvalidAttendedNotScr),
             new MaxLengthValidator("Appointment ID", 27, ErrorCodes.MissingAppointmentId,
                 ErrorCodes.InvalidAppointmentId),
+            new NhsNumValidator(),
             new RegexValidator("Episode Type", EpisodeTypeRegex(), ErrorCodes.MissingEpisodeType,
                 ErrorCodes.InvalidEpisodeType),
             new MaxLengthValidator("Batch ID", 9, ErrorCodes.MissingBatchId,

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidatorTests.cs
@@ -1,0 +1,82 @@
+using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+namespace ServiceLayer.Mesh.Tests.FileTypes.NbssAppointmentEvents.Validation;
+
+public class NhsNumValidatorTests : ValidationTestBase
+{
+    [Fact]
+    public void Validate_NhsNumMissing_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ParsedFileWithModifiedRecord(r => r.Fields.Remove("NHS Num"));
+
+        // Act
+        var validationErrors = Validate(file);
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "NHS Num",
+            "NHS Num is missing",
+            ErrorCodes.MissingNhsNum
+        );
+    }
+
+    [Theory]
+    [InlineData("308 407 5425")]       // we don't anticipate spaces
+    [InlineData("857320211")]          // too few character
+    [InlineData("90238807571")]        // Too many characters
+    [InlineData("159278895S")]         // invalid characters
+    public void Validate_NhsNumInvalidFormat_ReturnsValidationError(string value)
+    {
+        // Arrange
+        var file = ParsedFileWithModifiedRecord(r => r.Fields["NHS Num"] = value);
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "NHS Num",
+            "NHS Num is in an invalid format",
+            ErrorCodes.InvalidNhsNum
+        );
+    }
+
+    [Theory]
+    [InlineData("3244700471")]
+    [InlineData("7326012282")]
+    [InlineData("6245827145")]
+    [InlineData("4745895257")]
+    public void Validate_NhsNumInvalidCheckDigit_ReturnsValidationError(string value)
+    {
+        // Arrange
+        var file = ParsedFileWithModifiedRecord(r => r.Fields["NHS Num"] = value);
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "NHS Num",
+            "NHS Num has invalid check digit",
+            ErrorCodes.InvalidNhsNumCheckDigit
+        );
+    }
+
+    [Theory]
+    [InlineData("4941273230")]
+    [InlineData("6451357219")]
+    [InlineData("3365582983")]
+    [InlineData("8799244780")]
+    public void Validate_NHSNumValidFormat_NoValidationErrorsReturned(string value)
+    {
+        // Arrange
+        var file = ParsedFileWithModifiedRecord(r => r.Fields["NHS Num"] = value);
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        Assert.Empty(validationErrors);
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Validates that values in the "NHS Num" field within NBSS Appointment event records match the anticipated specification - a ten-digit string representation of an NHS number.

## Context

Anti-corruption layer.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
