### PR TITLE
feat: DTOSS-9178 - Add scope to validation errors

### DIFF
--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/MaxLengthValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/MaxLengthValidator.cs
@@ -20,6 +20,7 @@ public class MaxLengthValidator(
 
             yield return new ValidationError
             {
+                Scope = ValidationErrorScope.Record,
                 RowNumber = fileDataRecord.RowNumber,
                 Field = fieldName,
                 Error = error,
@@ -34,6 +35,7 @@ public class MaxLengthValidator(
 
             yield return new ValidationError
             {
+                Scope = ValidationErrorScope.Record,
                 RowNumber = fileDataRecord.RowNumber,
                 Field = fieldName,
                 Error = error,

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/NhsNumValidator.cs
@@ -11,6 +11,7 @@ public partial class NhsNumValidator() :
         {
             yield return new ValidationError
             {
+                Scope = ValidationErrorScope.Record,
                 RowNumber = rowNumber,
                 Field = FieldName,
                 Error = "NHS Num has invalid check digit",

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/RegexValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/RegexValidator.cs
@@ -20,6 +20,7 @@ public class RegexValidator(
         {
             yield return new ValidationError
             {
+                Scope = ValidationErrorScope.Record,
                 RowNumber = fileDataRecord.RowNumber,
                 Field = FieldName,
                 Error = $"{FieldName} is missing",
@@ -32,6 +33,7 @@ public class RegexValidator(
         {
             yield return new ValidationError
             {
+                Scope = ValidationErrorScope.Record,
                 RowNumber = fileDataRecord.RowNumber,
                 Field = FieldName,
                 Error = $"{FieldName} is in an invalid format",

--- a/src/ServiceLayer.Mesh/ValidationError.cs
+++ b/src/ServiceLayer.Mesh/ValidationError.cs
@@ -9,4 +9,6 @@ public class ValidationError
     public required string Code { get; set; }
 
     public required string Error { get; set; }
+
+    public required ValidationErrorScope Scope { get; set; }
 }

--- a/src/ServiceLayer.Mesh/ValidationErrorScope.cs
+++ b/src/ServiceLayer.Mesh/ValidationErrorScope.cs
@@ -1,0 +1,9 @@
+namespace ServiceLayer.Mesh;
+
+public enum ValidationErrorScope
+{
+    File,
+    Record,
+    Header,
+    Trailer
+}

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/MaxLengthValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/MaxLengthValidatorTests.cs
@@ -27,7 +27,7 @@ public class MaxLengthValidatorTests
         var errors = validator.Validate(record).ToList();
 
         // Assert
-        errors.ShouldContainValidationError(FieldName, expectedError, MissingCode, 1);
+        errors.ShouldContainValidationError(FieldName, expectedError, MissingCode, ValidationErrorScope.Record, 1);
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class MaxLengthValidatorTests
         var errors = validator.Validate(record).ToList();
 
         // Assert
-        errors.ShouldContainValidationError(FieldName, "TestField is missing or empty", MissingCode, 2);
+        errors.ShouldContainValidationError(FieldName, "TestField is missing or empty", MissingCode, ValidationErrorScope.Record,2);
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class MaxLengthValidatorTests
         var errors = validator.Validate(record).ToList();
 
         // Assert
-        errors.ShouldContainValidationError(FieldName, $"TestField exceeds maximum length of {maxLength}", TooLongCode, 4);
+        errors.ShouldContainValidationError(FieldName, $"TestField exceeds maximum length of {maxLength}", TooLongCode, ValidationErrorScope.Record,4);
     }
 
     [Theory]

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/RegexValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/RegexValidatorTests.cs
@@ -27,7 +27,7 @@ public class RegexValidatorTests
         var errors = validator.Validate(record).ToList();
 
         // Assert
-        errors.ShouldContainValidationError(FieldName, $"{FieldName} is missing", MissingCode, 1);
+        errors.ShouldContainValidationError(FieldName, $"{FieldName} is missing", MissingCode, ValidationErrorScope.Record,1);
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class RegexValidatorTests
         var errors = validator.Validate(record).ToList();
 
         // Assert
-        errors.ShouldContainValidationError(FieldName, $"{FieldName} is in an invalid format", InvalidFormatCode, 2);
+        errors.ShouldContainValidationError(FieldName, $"{FieldName} is in an invalid format", InvalidFormatCode,ValidationErrorScope.Record, 2);
     }
 
     [Theory]

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationErrorAssertions.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationErrorAssertions.cs
@@ -7,6 +7,7 @@ public static class ValidationErrorAssertions
         string expectedField,
         string expectedError,
         string expectedCode,
+        ValidationErrorScope expectedScope = ValidationErrorScope.Record,
         int? expectedRowNumber = null)
     {
         var error = errors.FirstOrDefault(e =>
@@ -16,7 +17,7 @@ public static class ValidationErrorAssertions
             (expectedRowNumber == null || e.RowNumber == expectedRowNumber)
         );
 
-        Assert.True(error != null, $"Expected validation error with Field: '{expectedField}', Error: '{expectedError}', Code: '{expectedCode}'{(expectedRowNumber != null ? $", RowNumber: {expectedRowNumber}" : "")}, but none was found.");
+        Assert.True(error != null, $"Expected validation error with Scope: '{expectedScope}', Field: '{expectedField}', Error: '{expectedError}', Code: '{expectedCode}'{(expectedRowNumber != null ? $", RowNumber: {expectedRowNumber}" : "")}, but none was found.");
 
     }
 }

--- a/tests/ServiceLayer.Mesh.Tests/Functions/FileTransformFunctionTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/Functions/FileTransformFunctionTests.cs
@@ -139,8 +139,8 @@ public class FileTransformFunctionTests : FunctionTestBase<FileTransformFunction
 
         var validationErrors = new List<ValidationError>
         {
-            new() { Code = "NBSSAPPT001", Error = "error message", Field = "field", RowNumber = 1 },
-            new() { Code = "NBSSAPPT002", Error = "error message 2", Field = "field 2" }
+            new() { Scope = ValidationErrorScope.Record, Code = "NBSSAPPT001", Error = "error message", Field = "field", RowNumber = 1 },
+            new() { Scope = ValidationErrorScope.Header, Code = "NBSSAPPT002", Error = "error message 2", Field = "field 2" }
         };
 
         _fileTransformerMock.Setup(c => c.TransformFileAsync(expectedStream, file))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Enhance the ValidationError to include a Scope property, rather than trying to combine this information within the Field property as currently.

## Context

Separates structure from semantics, avoids polluting the ValidationError Field property with additional info.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
