### PR TITLE
fix: disambiguate environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,10 @@ ASPNETCORE_ENVIRONMENT=Development
 FileDiscoveryTimerExpression=0 */5 * * * *
 MeshHandshakeTimerExpression=0 0 0 * * * # Midnight
 FileRetryTimerExpression=0 0 * * * *
-QueueUrl=http://127.0.0.1:10001
 FileExtractQueueName=file-extract
 FileTransformQueueName=file-transform
 StaleHours=12
-BlobContainerName=incoming-mesh-files
+MeshBlobContainerName=incoming-mesh-files
 
 
 # API Configuration

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,10 +53,11 @@ services:
       MeshPassword: "${MeshPassword}"
       MeshSharedKey: "${MeshSharedKey}"
       AZURITE_CONNECTION_STRING: "${AZURITE_CONNECTION_STRING}"
-      MeshStorageAccountUrl: "${AZURITE_CONNECTION_STRING}"
+      MeshBlobStorageUrl: "${AZURITE_CONNECTION_STRING}"
+      MeshQueueStorageUrl: "${AZURITE_CONNECTION_STRING}"
       ASPNETCORE_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT}"
       ASPNETCORE_URLS: "http://0.0.0.0:8080"
-      BlobContainerName: "${BlobContainerName}"
+      MeshBlobContainerName: "${MeshBlobContainerName}"
     ports:
       - "${MESH_INGEST_PORT}:8080"
     healthcheck:

--- a/src/ServiceLayer.Mesh/Messaging/ServiceCollectionExtensions.cs
+++ b/src/ServiceLayer.Mesh/Messaging/ServiceCollectionExtensions.cs
@@ -23,8 +23,8 @@ internal static class ServiceCollectionExtensions
                 return new QueueServiceClient(connectionString, queueClientOptions);
             }
 
-            var meshStorageAccountUrl = EnvironmentVariables.GetRequired("MeshStorageAccountUrl");
-            return new QueueServiceClient(new Uri(meshStorageAccountUrl), new ManagedIdentityCredential(), queueClientOptions);
+            var meshQueueStorageUrl = EnvironmentVariables.GetRequired("MeshQueueStorageUrl");
+            return new QueueServiceClient(new Uri(meshQueueStorageUrl), new ManagedIdentityCredential(), queueClientOptions);
         });
 
         services.AddSingleton<IFileExtractQueueClient, FileExtractQueueClient>();

--- a/src/ServiceLayer.Mesh/Storage/ServiceCollectionExtensions.cs
+++ b/src/ServiceLayer.Mesh/Storage/ServiceCollectionExtensions.cs
@@ -11,16 +11,16 @@ internal static class ServiceCollectionExtensions
     {
         services.AddSingleton(_ =>
         {
-            var containerName = EnvironmentVariables.GetRequired("BlobContainerName");
+            var containerName = EnvironmentVariables.GetRequired("MeshBlobContainerName");
 
             if (isLocalEnvironment)
             {
                 return new BlobContainerClient(EnvironmentVariables.GetRequired("AzureWebJobsStorage"),containerName);
             }
 
-            var meshStorageAccountUrl = EnvironmentVariables.GetRequired("MeshStorageAccountUrl");
+            var meshBlobStorageUrl = EnvironmentVariables.GetRequired("MeshBlobStorageUrl");
 
-            var serviceClient = new BlobServiceClient(new Uri(meshStorageAccountUrl), new ManagedIdentityCredential());
+            var serviceClient = new BlobServiceClient(new Uri(meshBlobStorageUrl), new ManagedIdentityCredential());
             return serviceClient.GetBlobContainerClient(containerName);
         });
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Rename BlobContainerName environment variable to MeshBlobContainerName
- Differentiate between environment variables containing URL for blob storage and queue storage
- Remove redundant QueueUrl from .env.example

## Context

Accurate, unambiguous configuration

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
