### PR TITLE
DTOSS-9177: Abort validation if too many errors are returned

### DIFF
--- a/src/ServiceLayer.Mesh/Configuration/AppConfiguration.cs
+++ b/src/ServiceLayer.Mesh/Configuration/AppConfiguration.cs
@@ -6,7 +6,8 @@ public class AppConfiguration :
     IFileTransformQueueClientConfiguration,
     IFileTransformFunctionConfiguration,
     IFileRetryFunctionConfiguration,
-    IMeshHandshakeFunctionConfiguration
+    IMeshHandshakeFunctionConfiguration,
+    IValidationRunnerConfiguration
 {
     public string NbssMeshMailboxId => GetRequired("NbssMailboxId");
 
@@ -14,24 +15,12 @@ public class AppConfiguration :
 
     public string FileTransformQueueName => GetRequired("FileTransformQueueName");
 
-    public int StaleHours => GetRequiredInt("StaleHours");
+    public int MaximumValidationErrors => GetOptionalInt("MaximumValidationErrors", 100);
 
-    private static string GetRequired(string key)
-    {
-        var value = EnvironmentVariables.GetRequired(key);
+    public int StaleHours => GetOptionalInt("StaleHours", 12);
 
-        return value;
-    }
-
-    private static int GetRequiredInt(string key)
-    {
-        var value = GetRequired(key);
-
-        if (!int.TryParse(value, out var intValue))
-        {
-            throw new InvalidOperationException($"Environment variable '{key}' is not a valid integer");
-        }
-
-        return intValue;
-    }
+    private static string GetRequired(string key) =>
+        EnvironmentVariables.GetRequired(key);
+    private static int GetOptionalInt(string key, int defaultValue) =>
+        EnvironmentVariables.GetOptionalInt(key, defaultValue);
 }

--- a/src/ServiceLayer.Mesh/Configuration/IValidationRunnerConfiguration.cs
+++ b/src/ServiceLayer.Mesh/Configuration/IValidationRunnerConfiguration.cs
@@ -1,0 +1,6 @@
+namespace ServiceLayer.Mesh.Configuration;
+
+public interface IValidationRunnerConfiguration
+{
+    int MaximumValidationErrors { get; }
+}

--- a/src/ServiceLayer.Mesh/Configuration/ServiceCollectionExtensions.cs
+++ b/src/ServiceLayer.Mesh/Configuration/ServiceCollectionExtensions.cs
@@ -6,12 +6,16 @@ internal static class ServiceCollectionExtensions
 {
     internal static IServiceCollection AddApplicationConfiguration(this IServiceCollection services)
     {
-        services.AddTransient<IFileDiscoveryFunctionConfiguration, AppConfiguration>();
-        services.AddTransient<IFileExtractQueueClientConfiguration, AppConfiguration>();
-        services.AddTransient<IFileTransformQueueClientConfiguration, AppConfiguration>();
-        services.AddTransient<IMeshHandshakeFunctionConfiguration, AppConfiguration>();
-        services.AddTransient<IFileRetryFunctionConfiguration, AppConfiguration>();
-        services.AddTransient<IFileTransformFunctionConfiguration, AppConfiguration>();
+        var implementationType = typeof(AppConfiguration);
+
+        var interfaces = implementationType
+            .GetInterfaces()
+            .Where(i => i.Namespace == implementationType.Namespace);
+
+        foreach (var serviceType in interfaces)
+        {
+            services.AddTransient(serviceType, implementationType);
+        }
 
         return services;
     }

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ErrorCodes.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ErrorCodes.cs
@@ -71,4 +71,5 @@ public static class ErrorCodes
     public const string MissingActionTimestamp = "NBSSAPPT067";
     public const string InvalidActionTimestamp = "NBSSAPPT068";
     public const string UnknownRecordTypeIdentifier = "NBSSAPPT069";
+    public const string ValidationAborted = "NBSSAPPT999";
 }

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidationRunner.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidationRunner.cs
@@ -1,8 +1,10 @@
+using ServiceLayer.Mesh.Configuration;
 using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
 
 namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
 
 public class ValidationRunner(
+    IValidationRunnerConfiguration configuration,
     IEnumerable<IFileValidator> fileValidators,
     IEnumerable<IRecordValidator> recordValidators)
     : IValidationRunner
@@ -11,18 +13,61 @@ public class ValidationRunner(
     {
         var errors = new List<ValidationError>();
 
-        foreach (var validator in fileValidators)
+        RunFileValidators(file, errors);
+        if (errors.Count >= configuration.MaximumValidationErrors)
         {
-            errors.AddRange(validator.Validate(file));
+            return FinalizeEarly(errors);
         }
 
-        foreach (var dataRecord in file.DataRecords)
+        RunRecordValidators(file, errors);
+        if (errors.Count >= configuration.MaximumValidationErrors)
         {
-            foreach (var recordValidator in recordValidators)
+            return FinalizeEarly(errors);
+        }
+
+        return errors;
+    }
+
+    private void RunFileValidators(ParsedFile file, List<ValidationError> errors)
+    {
+        foreach (var validator in fileValidators)
+        {
+            var results = validator.Validate(file);
+            AddErrorsWithCap(results, errors);
+            if (errors.Count >= configuration.MaximumValidationErrors) return;
+        }
+    }
+
+    private void RunRecordValidators(ParsedFile file, List<ValidationError> errors)
+    {
+        foreach (var record in file.DataRecords)
+        {
+            foreach (var validator in recordValidators)
             {
-                errors.AddRange(recordValidator.Validate(dataRecord));
+                var results = validator.Validate(record);
+                AddErrorsWithCap(results, errors);
+                if (errors.Count >= configuration.MaximumValidationErrors) return;
             }
         }
+    }
+
+    private void AddErrorsWithCap(IEnumerable<ValidationError> newErrors, List<ValidationError> existingErrors)
+    {
+        foreach (var error in newErrors)
+        {
+            if (existingErrors.Count >= configuration.MaximumValidationErrors) break;
+            existingErrors.Add(error);
+        }
+    }
+
+    private List<ValidationError> FinalizeEarly(List<ValidationError> errors)
+    {
+        errors.Add(new ValidationError
+        {
+            Code = ErrorCodes.ValidationAborted,
+            Error = $"Validation aborted after {configuration.MaximumValidationErrors} errors encountered",
+            Scope = ValidationErrorScope.File
+        });
 
         return errors;
     }

--- a/src/ServiceLayer.Mesh/ValidationError.cs
+++ b/src/ServiceLayer.Mesh/ValidationError.cs
@@ -4,7 +4,7 @@ public class ValidationError
 {
     public int? RowNumber { get; set; }
 
-    public required string Field { get; set; }
+    public string? Field { get; set; }
 
     public required string Code { get; set; }
 

--- a/src/ServiceLayer.Shared/EnvironmentVariables.cs
+++ b/src/ServiceLayer.Shared/EnvironmentVariables.cs
@@ -19,4 +19,33 @@ public static class EnvironmentVariables
 
         return value;
     }
+
+    public static int GetRequiredInt(string key)
+    {
+        var value = GetRequired(key);
+
+        if (!int.TryParse(value, out var intValue))
+        {
+            throw new InvalidOperationException($"Environment variable '{key}' is not a valid integer");
+        }
+
+        return intValue;
+    }
+
+    public static int GetOptionalInt(string key, int defaultValue)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return defaultValue;
+        }
+
+        if (!int.TryParse(value, out var intValue))
+        {
+            throw new InvalidOperationException($"Environment variable '{key}' is not a valid integer");
+        }
+
+        return intValue;
+    }
 }

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationRunnerTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationRunnerTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using ServiceLayer.Mesh.Configuration;
 using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
 using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
 
@@ -6,6 +7,13 @@ namespace ServiceLayer.Mesh.Tests.FileTypes.NbssAppointmentEvents.Validation;
 
 public class ValidationRunnerTests
 {
+    private readonly Mock<IValidationRunnerConfiguration> _configurationMock = new();
+
+    public ValidationRunnerTests()
+    {
+        _configurationMock.Setup(c => c.MaximumValidationErrors).Returns(100);
+    }
+
     [Fact]
     public void Validate_FileAndRecordValidatorsReturnErrors_ReturnsAllErrors()
     {
@@ -50,6 +58,7 @@ public class ValidationRunnerTests
             .Returns([recordValidationError2, recordValidationError3]);
 
         var runner = new ValidationRunner(
+            _configurationMock.Object,
             [fileValidator1.Object, fileValidator2.Object],
             [recordValidator1.Object, recordValidator2.Object]);
 
@@ -100,6 +109,7 @@ public class ValidationRunnerTests
             .Returns([recordValidationError2, recordValidationError3]);
 
         var runner = new ValidationRunner(
+            _configurationMock.Object,
             [fileValidator1.Object, fileValidator2.Object],
             [recordValidator1.Object, recordValidator2.Object]);
 
@@ -149,6 +159,7 @@ public class ValidationRunnerTests
             .Returns([]);
 
         var runner = new ValidationRunner(
+            _configurationMock.Object,
             [fileValidator1.Object, fileValidator2.Object],
             [recordValidator1.Object, recordValidator2.Object]);
 
@@ -189,6 +200,7 @@ public class ValidationRunnerTests
             .Returns([]);
 
         var runner = new ValidationRunner(
+            _configurationMock.Object,
             [fileValidator1.Object, fileValidator2.Object],
             [recordValidator1.Object, recordValidator2.Object]);
 
@@ -197,6 +209,162 @@ public class ValidationRunnerTests
 
         // Assert
         Assert.Empty(results);
+    }
+
+    [Theory]
+    [InlineData(19, 10, 10, true, 20)]
+    [InlineData(20, 10, 10, true, 21)]
+    [InlineData(21, 10, 10, false, 20)]
+    [InlineData(100, 49, 50, false, 99)]
+    [InlineData(100, 100, 0, true, 101)]
+    [InlineData(100, 0, 100, true, 101)]
+    [InlineData(100, 100, 100, true, 101)]
+    [InlineData(100, 200, 200, true, 101)]
+    public void Validate_TooManyFileValidationErrors_ReturnsFirstErrorsPlusIndicationOfEarlyTermination(
+        int maximumErrorCount, int validator1ErrorCount, int validator2ErrorCount, bool expectAborted,
+        int expectedErrorCount)
+    {
+        // Arrange
+        var file = new ParsedFile
+        {
+            DataRecords = [new FileDataRecord(), new FileDataRecord()]
+        };
+
+        var fileValidator1 = new Mock<IFileValidator>();
+        fileValidator1
+            .Setup(v => v.Validate(file))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, validator1ErrorCount));
+        var fileValidator2 = new Mock<IFileValidator>();
+        fileValidator2
+            .Setup(v => v.Validate(file))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, validator2ErrorCount));
+
+        _configurationMock.Setup(c => c.MaximumValidationErrors)
+            .Returns(maximumErrorCount);
+
+        var runner = new ValidationRunner(
+            _configurationMock.Object,
+            [fileValidator1.Object, fileValidator2.Object], []);
+
+        // Act
+        var results = runner.Validate(file);
+
+        // Assert
+        Assert.Equal(expectedErrorCount, results.Count);
+        if (expectAborted)
+        {
+            AssertContainsValidationAbortedError(results, maximumErrorCount);
+        }
+        else
+        {
+            AssertDoesNotContainValidationAbortedError(results, maximumErrorCount);
+        }
+    }
+
+    [Theory]
+    [InlineData(39, 10, 10, true, 40)]
+    [InlineData(40, 10, 10, true, 41)]
+    [InlineData(41, 10, 10, false, 40)]
+    [InlineData(100, 24, 25, false, 98)]
+    [InlineData(100, 25, 25, true, 101)]
+    [InlineData(100, 50, 0, true, 101)]
+    [InlineData(100, 0, 50, true, 101)]
+    [InlineData(100, 50, 50, true, 101)]
+    [InlineData(100, 100, 100, true, 101)]
+    public void Validate_TooManyRecordValidatorErrors_ReturnsFirstErrorsPlusIndicationOfEarlyTermination(
+        int maximumErrorCount, int validator1ErrorCount, int validator2ErrorCount, bool expectAborted,
+        int expectedErrorCount)
+    {
+        // Arrange
+        var file = new ParsedFile
+        {
+            DataRecords = [new FileDataRecord(), new FileDataRecord()]
+        };
+
+        var recordValidator1 = new Mock<IRecordValidator>();
+        recordValidator1
+            .Setup(v => v.Validate(It.IsAny<FileDataRecord>()))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, validator1ErrorCount));
+        var recordValidator2 = new Mock<IRecordValidator>();
+        recordValidator2
+            .Setup(v => v.Validate(It.IsAny<FileDataRecord>()))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, validator2ErrorCount));
+
+        _configurationMock.Setup(c => c.MaximumValidationErrors)
+            .Returns(maximumErrorCount);
+
+        var runner = new ValidationRunner(_configurationMock.Object,
+            [], [recordValidator1.Object, recordValidator2.Object]);
+
+        // Act
+        var results = runner.Validate(file);
+
+        // Assert
+        Assert.Equal(expectedErrorCount, results.Count);
+        if (expectAborted)
+        {
+            AssertContainsValidationAbortedError(results, maximumErrorCount);
+        }
+        else
+        {
+            AssertDoesNotContainValidationAbortedError(results, maximumErrorCount);
+        }
+    }
+
+    [Theory]
+    [InlineData(29, 10, 10, true, 30)]
+    [InlineData(30, 10, 10, true, 31)]
+    [InlineData(31, 10, 10, false, 30)]
+    [InlineData(100, 49, 25, false, 99)]
+    [InlineData(100, 50, 25, true, 101)]
+    [InlineData(100, 100, 0, true, 101)]
+    [InlineData(100, 0, 50, true, 101)]
+    [InlineData(100, 100, 50, true, 101)]
+    [InlineData(100, 200, 100, true, 101)]
+    public void Validate_TooManyValidatorErrors_ReturnsFirstErrorsPlusIndicationOfEarlyTermination(
+        int maximumErrorCount, int fileValidatorErrorCount, int recordValidatorErrorCount, bool expectAborted,
+        int expectedErrorCount)
+    {
+        // Arrange
+        var file = new ParsedFile
+        {
+            DataRecords = [new FileDataRecord(), new FileDataRecord()]
+        };
+
+        var fileValidator = new Mock<IFileValidator>();
+        fileValidator
+            .Setup(v => v.Validate(file))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, fileValidatorErrorCount));
+        var recordValidator = new Mock<IRecordValidator>();
+        recordValidator
+            .Setup(v => v.Validate(It.IsAny<FileDataRecord>()))
+            .Returns(BuildValidationErrors(ValidationErrorScope.File, recordValidatorErrorCount));
+
+        _configurationMock.Setup(c => c.MaximumValidationErrors)
+            .Returns(maximumErrorCount);
+
+        var runner = new ValidationRunner(_configurationMock.Object,
+            [fileValidator.Object], [recordValidator.Object]);
+
+        // Act
+        var results = runner.Validate(file);
+
+        // Assert
+        Assert.Equal(expectedErrorCount, results.Count);
+        if (expectAborted)
+        {
+            AssertContainsValidationAbortedError(results, maximumErrorCount);
+        }
+        else
+        {
+            AssertDoesNotContainValidationAbortedError(results, maximumErrorCount);
+        }
+    }
+
+    private static IEnumerable<ValidationError> BuildValidationErrors(ValidationErrorScope scope, int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(_ => BuildValidationError(scope));
     }
 
     private static ValidationError BuildValidationError(ValidationErrorScope scope)
@@ -215,5 +383,27 @@ public class ValidationRunnerTests
         }
 
         return validationError;
+    }
+
+    private static void AssertContainsValidationAbortedError(IList<ValidationError> errors, int maximumErrors)
+    {
+        Assert.Contains(errors, BuildValidationAbortedPredicate(maximumErrors));
+    }
+
+    private static void AssertDoesNotContainValidationAbortedError(IList<ValidationError> errors, int maximumErrors)
+    {
+        Assert.DoesNotContain(errors, BuildValidationAbortedPredicate(maximumErrors));
+    }
+
+    private static Predicate<ValidationError> BuildValidationAbortedPredicate(int maximumErrors)
+    {
+        var errorMessage = $"Validation aborted after {maximumErrors} errors encountered";
+
+        return e =>
+            e.Code == ErrorCodes.ValidationAborted &&
+            e.Error == errorMessage &&
+            e.Scope == ValidationErrorScope.File &&
+            e.Field is null &&
+            e.RowNumber is null;
     }
 }

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationTestBase.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationTestBase.cs
@@ -1,3 +1,5 @@
+using Moq;
+using ServiceLayer.Mesh.Configuration;
 using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
 using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
 
@@ -5,6 +7,8 @@ namespace ServiceLayer.Mesh.Tests.FileTypes.NbssAppointmentEvents.Validation;
 
 public abstract class ValidationTestBase
 {
+    private readonly Mock<IValidationRunnerConfiguration> _configurationMock = new();
+
     protected readonly ValidationRunner SystemUnderTest;
 
     protected ValidationTestBase()
@@ -12,7 +16,9 @@ public abstract class ValidationTestBase
         var recordValidators = ValidatorRegistry.GetAllRecordValidators();
         var fileValidators = ValidatorRegistry.GetAllFileValidators();
 
-        SystemUnderTest = new ValidationRunner(fileValidators, recordValidators);
+        _configurationMock.Setup(c => c.MaximumValidationErrors).Returns(100);
+
+        SystemUnderTest = new ValidationRunner(_configurationMock.Object, fileValidators, recordValidators);
     }
 
     protected static ParsedFile ValidParsedFile =>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

If more than a configured number (default 100) of validation errors is encountered, abort validation and return a validation error indicating that validation did not complete exhaustively, along with the errors encountered so far.

## Context

Protects performance, reduces noise, improves clarity, prevents log spam.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
