### PR TITLE
feat: DTOSS-9159 - add file-level validation

### DIFF
--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/FileValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/FileValidator.cs
@@ -15,25 +15,10 @@ public partial class FileValidator : IFileValidator
 
     public IEnumerable<ValidationError> Validate(ParsedFile file)
     {
-        foreach (var error in ValidateHeaderPresence(file))
-        {
-            yield return error;
-        }
-
-        foreach (var error in ValidateTrailerPresence(file))
-        {
-            yield return error;
-        }
-
-        foreach (var error in ValidateExtractId(file))
-        {
-            yield return error;
-        }
-
-        foreach (var error in ValidateRecordCount(file))
-        {
-            yield return error;
-        }
+        return ValidateHeaderPresence(file)
+            .Concat(ValidateTrailerPresence(file))
+            .Concat(ValidateExtractId(file))
+            .Concat(ValidateRecordCount(file));
     }
 
     private static IEnumerable<ValidationError> ValidateHeaderPresence(ParsedFile file)
@@ -103,7 +88,9 @@ public partial class FileValidator : IFileValidator
                 Error = "Record count does not match value in header",
                 Scope = ValidationErrorScope.Trailer
             };
-        } else if (headerRecordCountErrors.Count == 0 && file.DataRecords.Count != int.Parse(file.FileHeader.RecordCount!))
+        }
+        else if (headerRecordCountErrors.Count == 0 &&
+            file.DataRecords.Count != int.Parse(file.FileHeader.RecordCount!))
         {
             yield return new ValidationError
             {

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/FileValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/FileValidator.cs
@@ -1,0 +1,122 @@
+using System.Text.RegularExpressions;
+using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
+
+namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+public partial class FileValidator : IFileValidator
+{
+    private readonly HeaderFieldRegexValidator _headerExtractIdValidator = new(
+        x => x.ExtractId, "Extract ID", ExtractIdRegex(),
+        ErrorCodes.MissingExtractId, ErrorCodes.InvalidExtractId);
+
+    private readonly HeaderFieldRegexValidator _headerIdRecordCountValidator = new(
+        x => x.RecordCount, "Record count", RecordCountRegex(),
+        ErrorCodes.MissingRecordCount, ErrorCodes.InvalidRecordCount);
+
+    public IEnumerable<ValidationError> Validate(ParsedFile file)
+    {
+        foreach (var error in ValidateHeaderPresence(file))
+        {
+            yield return error;
+        }
+
+        foreach (var error in ValidateTrailerPresence(file))
+        {
+            yield return error;
+        }
+
+        foreach (var error in ValidateExtractId(file))
+        {
+            yield return error;
+        }
+
+        foreach (var error in ValidateRecordCount(file))
+        {
+            yield return error;
+        }
+    }
+
+    private static IEnumerable<ValidationError> ValidateHeaderPresence(ParsedFile file)
+    {
+        if (file.FileHeader == null)
+        {
+            yield return new ValidationError
+            {
+                Code = ErrorCodes.MissingHeader,
+                Error = "Header is missing",
+                Scope = ValidationErrorScope.File
+            };
+        }
+    }
+
+    private static IEnumerable<ValidationError> ValidateTrailerPresence(ParsedFile file)
+    {
+        if (file.FileTrailer == null)
+        {
+            yield return new ValidationError
+            {
+                Code = ErrorCodes.MissingTrailer,
+                Error = "Trailer is missing",
+                Scope = ValidationErrorScope.File
+            };
+        }
+    }
+
+    private IEnumerable<ValidationError> ValidateExtractId(ParsedFile file)
+    {
+        if (file.FileHeader == null) yield break;
+
+        foreach (var error in _headerExtractIdValidator.Validate(file))
+        {
+            yield return error;
+        }
+
+        if (file.FileTrailer != null && file.FileHeader.ExtractId != file.FileTrailer.ExtractId)
+        {
+            yield return new ValidationError
+            {
+                Field = "Extract ID",
+                Code = ErrorCodes.InconsistentExtractId,
+                Error = "Extract ID does not match value in header",
+                Scope = ValidationErrorScope.Trailer
+            };
+        }
+    }
+
+    private IEnumerable<ValidationError> ValidateRecordCount(ParsedFile file)
+    {
+        if (file.FileHeader == null) yield break;
+
+        var headerRecordCountErrors = _headerIdRecordCountValidator.Validate(file).ToList();
+
+        foreach (var error in headerRecordCountErrors)
+        {
+            yield return error;
+        }
+
+        if (file.FileTrailer != null && file.FileHeader.RecordCount != file.FileTrailer.RecordCount)
+        {
+            yield return new ValidationError
+            {
+                Field = "Record count",
+                Code = ErrorCodes.InconsistentRecordCount,
+                Error = "Record count does not match value in header",
+                Scope = ValidationErrorScope.Trailer
+            };
+        } else if (headerRecordCountErrors.Count == 0 && file.DataRecords.Count != int.Parse(file.FileHeader.RecordCount!))
+        {
+            yield return new ValidationError
+            {
+                Code = ErrorCodes.UnexpectedRecordCount,
+                Error = "Record count does not match value in header and trailer",
+                Scope = ValidationErrorScope.File
+            };
+        }
+    }
+
+    [GeneratedRegex(@"^\d{8}$")]
+    private static partial Regex ExtractIdRegex();
+
+    [GeneratedRegex(@"^(?!000000)\d{6}$")]
+    private static partial Regex RecordCountRegex();
+}

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/HeaderFieldRegexValidator.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/HeaderFieldRegexValidator.cs
@@ -1,0 +1,43 @@
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Models;
+
+namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+public class HeaderFieldRegexValidator(
+    Expression<Func<FileHeaderRecord, string?>> fieldSelector,
+    string fieldName,
+    Regex pattern,
+    string errorCodeMissing,
+    string errorCodeInvalidFormat)
+    : IFileValidator
+{
+    public IEnumerable<ValidationError> Validate(ParsedFile file)
+    {
+        var header = file.FileHeader!;
+        var value = fieldSelector.Compile().Invoke(header);
+
+        if (value == null)
+        {
+            yield return new ValidationError
+            {
+                Scope = ValidationErrorScope.Header,
+                Field = fieldName,
+                Error = $"{fieldName} is missing",
+                Code = errorCodeMissing,
+            };
+            yield break;
+        }
+
+        if (!pattern.IsMatch(value))
+        {
+            yield return new ValidationError
+            {
+                Scope = ValidationErrorScope.Header,
+                Field = fieldName,
+                Error = $"{fieldName} is in an invalid format",
+                Code = errorCodeInvalidFormat,
+            };
+        }
+    }
+}

--- a/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidatorRegistry.cs
+++ b/src/ServiceLayer.Mesh/FileTypes/NbssAppointmentEvents/Validation/ValidatorRegistry.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices.JavaScript;
 using System.Text.RegularExpressions;
 
 namespace ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
@@ -69,7 +68,7 @@ public static partial class ValidatorRegistry
 
     public static IEnumerable<IFileValidator> GetAllFileValidators()
     {
-        return [];
+        return [new FileValidator()];
     }
 
     [GeneratedRegex(@"^[BCU]$", RegexOptions.Compiled)]

--- a/src/ServiceLayer.Mesh/ValidationError.cs
+++ b/src/ServiceLayer.Mesh/ValidationError.cs
@@ -4,7 +4,7 @@ public class ValidationError
 {
     public int? RowNumber { get; set; }
 
-    public required string Field { get; set; }
+    public string? Field { get; set; }
 
     public required string Code { get; set; }
 

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/TestDataBuilder.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/TestDataBuilder.cs
@@ -12,7 +12,7 @@ public static class TestDataBuilder
             ExtractId = "00000107",
             TransferStartDate = "20250519",
             TransferStartTime = "153806",
-            RecordCount = numberOfRecords.ToString()
+            RecordCount = numberOfRecords.ToString("D6")
         };
 
         var trailer = new FileTrailerRecord
@@ -21,7 +21,7 @@ public static class TestDataBuilder
             ExtractId = "00000107",
             TransferEndDate = "20250519",
             TransferEndTime = "153957",
-            RecordCount = numberOfRecords.ToString()
+            RecordCount = numberOfRecords.ToString("D6")
         };
 
         var dataRecords = Enumerable.Range(1, numberOfRecords)

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/FileValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/FileValidatorTests.cs
@@ -1,0 +1,211 @@
+using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+namespace ServiceLayer.Mesh.Tests.FileTypes.NbssAppointmentEvents.Validation;
+
+public class FileValidatorTests : ValidationTestBase
+{
+    [Fact]
+    public void Validate_HeaderMissing_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader = null;
+
+        // Act
+        var validationErrors = Validate(file);
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            null,
+            "Header is missing",
+            ErrorCodes.MissingHeader,
+            ValidationErrorScope.File
+            );
+    }
+
+    [Fact]
+    public void Validate_TrailerMissing_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileTrailer = null;
+
+        // Act
+        var validationErrors = Validate(file);
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            null,
+            "Trailer is missing",
+            ErrorCodes.MissingTrailer,
+            ValidationErrorScope.File
+        );
+    }
+
+    [Fact]
+    public void Validate_HeaderExtractIdMissing_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader!.ExtractId = null;
+
+        // Act
+        var validationErrors = Validate(file);
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Extract ID",
+            "Extract ID is missing",
+            ErrorCodes.MissingExtractId,
+            ValidationErrorScope.Header
+        );
+    }
+
+    [Theory]
+    [InlineData("1")]         // Missing leading zeroes
+    [InlineData("100000000")] // Too large
+    [InlineData("")]          // Blank
+    [InlineData("asdf")]      // NaN
+    public void Validate_HeaderExtractIdInvalidFormat_ReturnsValidationError(string value)
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader!.ExtractId = value;
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Extract ID",
+            "Extract ID is in an invalid format",
+            ErrorCodes.InvalidExtractId,
+            ValidationErrorScope.Header
+        );
+    }
+
+    [Theory]
+    [InlineData("00000000")]
+    [InlineData("00000001")]
+    [InlineData("99999999")]
+    public void Validate_HeaderExtractIdValidFormat_NoValidationErrorsReturned(string value)
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader!.ExtractId = value;
+        file.FileTrailer!.ExtractId = value;
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        Assert.Empty(validationErrors);
+    }
+
+    [Fact]
+    public void Validate_HeaderRecordCountMissing_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader!.RecordCount = null;
+
+        // Act
+        var validationErrors = Validate(file);
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Record count",
+            "Record count is missing",
+            ErrorCodes.MissingRecordCount,
+            ValidationErrorScope.Header
+        );
+    }
+
+    [Theory]
+    [InlineData("1")]         // Missing leading zeroes
+    [InlineData("000000")]    // All zeroes
+    [InlineData("1000000")]   // Too large
+    [InlineData("")]          // Blank
+    [InlineData("asdf")]      // NaN
+    public void Validate_HeaderRecordCountInvalidFormat_ReturnsValidationError(string value)
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileHeader!.RecordCount = value;
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Record count",
+            "Record count is in an invalid format",
+            ErrorCodes.InvalidRecordCount,
+            ValidationErrorScope.Header
+        );
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("00000108")]
+    public void Validate_TrailerExtractIdMismatch_ReturnsValidationError(string? value)
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileTrailer!.ExtractId = value;
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Extract ID",
+            "Extract ID does not match value in header",
+            ErrorCodes.InconsistentExtractId,
+            ValidationErrorScope.Trailer
+        );
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("000002")]
+    [InlineData("000004")]
+    public void Validate_TrailerRecordCountMismatch_ReturnsValidationError(string? value)
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.FileTrailer!.RecordCount = value;
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            "Record count",
+            "Record count does not match value in header",
+            ErrorCodes.InconsistentRecordCount,
+            ValidationErrorScope.Trailer
+        );
+    }
+
+    [Fact]
+    public void Validate_UnexpectedRecordCount_ReturnsValidationError()
+    {
+        // Arrange
+        var file = ValidParsedFile;
+        file.DataRecords.RemoveAt(0);
+
+        // Act
+        var validationErrors = Validate(file).ToList();
+
+        // Assert
+        validationErrors.ShouldContainValidationError(
+            null,
+            "Record count does not match value in header and trailer",
+            ErrorCodes.UnexpectedRecordCount,
+            ValidationErrorScope.File
+        );
+    }
+}

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/HeaderFieldRegexValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/HeaderFieldRegexValidatorTests.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+using ServiceLayer.Mesh.FileTypes.NbssAppointmentEvents.Validation;
+
+namespace ServiceLayer.Mesh.Tests.FileTypes.NbssAppointmentEvents.Validation;
+
+public partial class HeaderFieldRegexValidatorTests
+{
+    private const string FieldName = "TestField";
+    private const string MissingCode = "ERR001";
+    private const string InvalidFormatCode = "ERR002";
+    private readonly Regex _pattern = TestRegex();
+
+    [Fact]
+    public void Validate_NullValue_ShouldReturnMissingError()
+    {
+        // Arrange
+        var file = TestDataBuilder.BuildValidParsedFile();
+        file.FileHeader!.ExtractId = null;
+
+        var validator = new HeaderFieldRegexValidator(x => x.ExtractId, FieldName, _pattern, MissingCode, InvalidFormatCode);
+
+        // Act
+        var errors = validator.Validate(file).ToList();
+
+        // Assert
+        errors.ShouldContainValidationError(FieldName, $"{FieldName} is missing", MissingCode, ValidationErrorScope.Header);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("invalid")]
+    public void Validate_ValueNotMatchingPattern_ShouldReturnInvalidFormatError(string invalidValue)
+    {
+        // Arrange
+        var file = TestDataBuilder.BuildValidParsedFile();
+        file.FileHeader!.ExtractId = invalidValue;
+
+        var validator = new HeaderFieldRegexValidator(x => x.ExtractId, FieldName, _pattern, MissingCode, InvalidFormatCode);
+
+        // Act
+        var errors = validator.Validate(file).ToList();
+
+        // Assert
+        errors.ShouldContainValidationError(FieldName, $"{FieldName} is in an invalid format", InvalidFormatCode,ValidationErrorScope.Header);
+    }
+
+    [Theory]
+    [InlineData("AB12")]
+    [InlineData("CD34")]
+    public void Validate_ValueMatchingPattern_ShouldReturnNoErrors(string validValue)
+    {
+        // Arrange
+        var file = TestDataBuilder.BuildValidParsedFile();
+        file.FileHeader!.ExtractId = validValue;
+
+        var validator = new HeaderFieldRegexValidator(x => x.ExtractId, FieldName, _pattern, MissingCode, InvalidFormatCode);
+
+        // Act
+        var errors = validator.Validate(file).ToList();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [GeneratedRegex(@"^[A-Z]{2}\d{2}$", RegexOptions.Compiled)]
+    private static partial Regex TestRegex();
+}

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/RegexValidatorTests.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/RegexValidatorTests.cs
@@ -56,6 +56,7 @@ public partial class RegexValidatorTests
     [InlineData("CD34")]
     public void Validate_ValueMatchingPattern_ShouldReturnNoErrors(string validValue)
     {
+        // Arrange
         var record = new FileDataRecord
         {
             RowNumber = 3
@@ -64,8 +65,10 @@ public partial class RegexValidatorTests
 
         var validator = new RegexValidator(FieldName, _pattern, MissingCode, InvalidFormatCode);
 
+        // Act
         var errors = validator.Validate(record).ToList();
 
+        // Assert
         Assert.Empty(errors);
     }
 

--- a/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationErrorAssertions.cs
+++ b/tests/ServiceLayer.Mesh.Tests/FileTypes/NbssAppointmentEvents/Validation/ValidationErrorAssertions.cs
@@ -4,7 +4,7 @@ public static class ValidationErrorAssertions
 {
     public static void ShouldContainValidationError(
         this IEnumerable<ValidationError> errors,
-        string expectedField,
+        string? expectedField,
         string expectedError,
         string expectedCode,
         ValidationErrorScope expectedScope = ValidationErrorScope.Record,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Performs file-level validation of NBSS Appointment Event files, covering the following validation rules:

- NBSSAPPT002 - Header is missing
- NBSSAPPT003 - Extract ID is missing
- NBSSAPPT004 - Extract ID is in an invalid format
- NBSSAPPT005 - Record count is missing
- NBSSAPPT006 - Record count is in an invalid format
- NBSSAPPT007 - Trailer is missing
- NBSSAPPT008 - Extract ID does not match value in header
- NBSSAPPT009 - Record count does not match value in header
- NBSSAPPT011 - Record count does not match value in header and trailer



## Context

Acts as an anti-corruption layer at the point of ingress to NSP.
Ensures quality of data, guards against coding errors by both parties.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
